### PR TITLE
user profile image upload

### DIFF
--- a/social_login/models.py
+++ b/social_login/models.py
@@ -1,6 +1,8 @@
 from django.db import models
 from django.contrib.auth.models import AbstractBaseUser, BaseUserManager, PermissionsMixin
 
+DEFAULT = False
+UPLOAD = True
 
 class CreateUser(BaseUserManager):
     def create_user(self, email, nickname, **kwargs):
@@ -16,19 +18,20 @@ class CreateUser(BaseUserManager):
 
 class User(AbstractBaseUser, PermissionsMixin):
     email = models.EmailField(max_length=30, unique=True, null=False, blank=False)
-    created_at = models.DateTimeField(auto_now_add=True)
-    updated_at = models.DateTimeField(auto_now=True)
     nickname = models.CharField(
         max_length=15,
         unique=True,
     )
-    win = models.IntegerField(default=0)
-    lose = models.IntegerField(default=0)
-    rank = models.IntegerField(default=0)
-    profile = models.CharField(default='default', max_length=255)
+    profile = models.BooleanField(default=DEFAULT)
+    uploaded_image = models.TextField(default=None, null=True, blank=True)
     status_message = models.CharField(default='', max_length=50, null=False, blank=True)
     email_verification_code = models.CharField(max_length=6, null=True, blank=True)
     set_2fa = models.BooleanField(default=False)
+    win = models.IntegerField(default=0)
+    lose = models.IntegerField(default=0)
+    rank = models.IntegerField(default=0)
+    created_at = models.DateTimeField(auto_now_add=True)
+    updated_at = models.DateTimeField(auto_now=True)
     USERNAME_FIELD = 'email'
     REQUIRED_FIELDS = ['nickname', ]
     objects = CreateUser()

--- a/user_profile/serializers.py
+++ b/user_profile/serializers.py
@@ -2,10 +2,14 @@ from rest_framework import serializers
 from social_login.serializers import UserSerializer
 from social_login.models import User
 from friends.models import Friendship
+import base64
+
+DEFAULT = False
+UPLOAD = True
 
 
 class ProfileSerializer(UserSerializer):
-    profile_to = serializers.CharField(source='profile', max_length=255)
+    profile_to = serializers.BooleanField(source='profile')
     nickname_to = serializers.CharField(source='nickname', max_length=15)
     status_message_to = serializers.CharField(source='status_message', max_length=50, allow_blank=True)
     set_2fa_to = serializers.BooleanField(source='set_2fa')
@@ -16,9 +20,18 @@ class ProfileSerializer(UserSerializer):
 
     def get_user_info(self, user, friend):
         is_friend = Friendship.objects.filter(user=user.id, friend=friend.id).exists()
+
+        profile_b64data = ''
+        if friend.profile == DEFAULT:
+            profile_b64data = 'default'
+        elif friend.profile == UPLOAD and friend.uploaded_image is not None:
+            profile_b64data = friend.uploaded_image
+        else:
+            raise serializers.ValidationError({'error': f'{friend.nickname}\'s profile image not found'})
+
         info = {
             'nickname': friend.nickname,
-            'profile': friend.profile,
+            'profile': profile_b64data,
             'status_message': friend.status_message,
             'win': friend.win,
             'lose': friend.lose,
@@ -32,11 +45,24 @@ class ProfileSerializer(UserSerializer):
         for field in fields:
             value = validated_data.get(field, getattr(user, field))
             if value != getattr(user, field):
+                if field == 'profile' and value == UPLOAD and not user.uploaded_image:
+                    raise serializers.ValidationError({'error': 'you must upload a profile image first'})
                 if field == 'nickname':
                     value = check_nickname(value)
                 setattr(user, field, value)
         user.save()
         return user
+
+class ProfileImageSerializer(serializers.Serializer):
+    profile_image = serializers.ImageField(required=False, allow_empty_file=True)
+
+    def upload_profile(self, user, validated_data):
+        if 'profile_image' in validated_data and validated_data['profile_image'] is not None:
+            image_encoded = base64.b64encode(validated_data['profile_image'].read()).decode('utf-8')
+            user.uploaded_image = image_encoded
+        else:
+            user.uploaded_image = None
+        user.save()
 
 def check_nickname(nickname):
     if User.objects.filter(nickname=nickname).exists():

--- a/user_profile/views.py
+++ b/user_profile/views.py
@@ -38,6 +38,22 @@ class UserProfileView(APIView):
         except PermissionDenied as e:
             return Response({'error': str(e)}, status=status.HTTP_403_FORBIDDEN)
 
+    # 유저 프로필 이미지 업로드
+    def post(self, request):
+        try:
+            user = request.user
+            serializer = serializers.ProfileImageSerializer(data=request.data)
+            if serializer.is_valid():
+                serializer.upload_profile(user, serializer.validated_data)
+                return Response({'message': 'success'}, status=status.HTTP_200_OK)
+            return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)
+        except User.DoesNotExist:
+            return Response({'error': 'user not found'}, status=status.HTTP_404_NOT_FOUND)
+        except AuthenticationFailed as e:
+            return Response({'error': str(e)}, status=status.HTTP_401_UNAUTHORIZED)
+        except PermissionDenied as e:
+            return Response({'error': str(e)}, status=status.HTTP_403_FORBIDDEN)
+
 
 class SearchUserView(APIView):  # 받는 데이터(Query): keyword
     # 닉네임으로 유저 검색
@@ -59,6 +75,3 @@ class GameRankerView(APIView):
             return paginator.get_paginated_response(serializer.data)
         serializer = serializers.RankerUserSerializer(ranker, many=True)
         return Response(serializer.data, status=status.HTTP_200_OK)
-
-
-        


### PR DESCRIPTION
Users can now upload an image for their custom avatar(profile image).

- `profile` field is now BooleanField: False(0) for default image and True(1) for custom image.
- `uploaded_image` field is added: which is a TextField, where base64-encoded image is in.
- `POST` request added to `profile` app: for uploading an image. Form-data including `profile_image` key is required for this request. Value is going to be the image file(smaller, better).
- Error checking logics are added: in case like `there's no uploaded image but the profile field is set to True(1)`